### PR TITLE
Add state check to get_id and fix state check in rangemap

### DIFF
--- a/Core/esi.py
+++ b/Core/esi.py
@@ -31,7 +31,8 @@ def get_id(name, category):
     """
     if len(name) > 2:
         response = search(name, (category), True)
-        return response.get(category, [])[0]
+        if response:
+            return response.get(category, [])[0]
 
     return None
 

--- a/Navigation/commands.py
+++ b/Navigation/commands.py
@@ -2,29 +2,21 @@ from Navigation.config import DIST_USAGE, RANGE_USAGE
 from Navigation.controller import get_dotlan_map, get_jump_dist
 
 
-# TODO All these nested ifs are gross. Is there a better way?
-
-
 class NavBot:
     def __init__(self, slackbot):
 
         @slackbot.command('distance', help='Show distance between 2 systems. {}'.format(DIST_USAGE), aliases=['range'])
         def distance(channel, arg, user):
             slackbot.set_typing(channel)
-            if arg:
-                args = arg.split(' ', 1)
-                if len(args) == 2:
-                    dist = get_jump_dist(args)
-                    if dist and dist > 0:
-                        message = args[0].upper() + ' to ' + args[1].upper() + ': ' + '{:,.2f}ly'.format(dist)
-                    else:
-                        message = 'Invalid arguments. {}'.format(DIST_USAGE)
-                elif not len(args) == 2:
-                    message = 'Invalid number of systems. {}'.format(DIST_USAGE)
+            args = arg.split(' ', 1)
+            if len(args) == 2:
+                dist = get_jump_dist(args)
+                if dist and dist > 0:
+                    message = args[0].upper() + ' to ' + args[1].upper() + ': ' + '{:,.2f}ly'.format(dist)
                 else:
-                    message = 'Mentions are not a valid parameter.'
+                    message = 'Invalid arguments. {}'.format(DIST_USAGE)
             else:
-                message = 'Invalid number of systems. {}'.format(DIST_USAGE)
+                message = 'Invalid number of arguments. {}'.format(DIST_USAGE)
 
             return slackbot.post_message(channel, message)
 
@@ -32,18 +24,13 @@ class NavBot:
                                            '{}'.format(RANGE_USAGE))
         def rangemap(channel, arg, user):
             slackbot.set_typing(channel)
-            if arg:
-                args = arg.split(' ', -1)
-                if len(args):
-                    url = get_dotlan_map(args)
-                    if url:
-                        message = url
-                    else:
-                        message = 'Invalid arguments. {}'.format(RANGE_USAGE)
-                elif not len(args) == 3:
-                    message = 'Invalid number of arguments. {}'.format(RANGE_USAGE)
+            args = arg.split(' ', -1)
+            if len(args) == 3:
+                url = get_dotlan_map(args)
+                if url:
+                    message = url
                 else:
-                    message = 'Mentions are not a valid parameter.'
+                    message = 'Invalid arguments. {}'.format(RANGE_USAGE)
             else:
                 message = 'Invalid number of arguments. {}'.format(RANGE_USAGE)
 


### PR DESCRIPTION
Rangemap was accepting any length of argument as 'valid'. This caused a problem by not displaying an appropriate error message when arguments were invalid.

While fixing this I stumbled on esi.get_id causing a problem when invalid names were passed in and thus the result was not a valid list, throwing an index error when trying to access it in the return value.